### PR TITLE
update retail interface version

### DIFF
--- a/AutoCombatLogger.toc
+++ b/AutoCombatLogger.toc
@@ -1,5 +1,5 @@
 ## Interface: 100000
-## Interface-Retail: 90200
+## Interface-Retail: 100000
 ## Interface-Classic: 11403
 ## Interface-BCC: 20504
 ## Interface-Wrath: 30400


### PR DESCRIPTION
`Interface-Retail` is prioritized, so the WoW client falsely reports the addon as out of date.

![WoWScrnShot_102722_235026](https://user-images.githubusercontent.com/9218035/198498662-31986e2e-a916-40a6-9702-aca9ae53e985.jpg)
