### PR TITLE
Fix logging in SoD BFD

### DIFF
--- a/AutoCombatLogger.lua
+++ b/AutoCombatLogger.lua
@@ -857,7 +857,7 @@ function AutoCombatLogger:ProcessZoneChange()
 		profile.selectedRaids[nonlocalZone][difficulty]== true) then
 			self:EnableCombatLogging("Custom Raid: ".._G.tostring(nonlocalZone))
 	elseif (type == "party" and diffCheck and not isGarrison and
-		maxPlayers == 10) then
+		maxPlayers > 5) then
 		self:EnableCombatLogging("Raid")
 	elseif (type == "party" and diffCheck and not isGarrison and
 		profile.logInstance == "Yes") then

--- a/AutoCombatLogger.lua
+++ b/AutoCombatLogger.lua
@@ -857,6 +857,9 @@ function AutoCombatLogger:ProcessZoneChange()
 		profile.selectedRaids[nonlocalZone][difficulty]== true) then
 			self:EnableCombatLogging("Custom Raid: ".._G.tostring(nonlocalZone))
 	elseif (type == "party" and diffCheck and not isGarrison and
+		maxPlayers == 10) then
+		self:EnableCombatLogging("Raid")
+	elseif (type == "party" and diffCheck and not isGarrison and
 		profile.logInstance == "Yes") then
 		self:EnableCombatLogging("Instance")
 	elseif (type == "party" and diffCheck and not isGarrison and


### PR DESCRIPTION
I tested this in BFD and it works. I also tested it in Stockades which has `maxPlayers = 5` so it didn't trigger.

I don't know if this is the "right" way to fix this problem. Would this logic trigger logging in UBRS for example?